### PR TITLE
feat: add opentelemetry

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,5 +12,5 @@
 {xref_checks, [undefined_function_calls]}.
 
 {deps, [
-  {opentelemetry_api,  "~> 1.0"}
+  {opentelemetry_api,  "1.0.2"}
   ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -12,5 +12,5 @@
 {xref_checks, [undefined_function_calls]}.
 
 {deps, [
-  {opentelemetry_api,  "1.0.2"}
+  {opentelemetry_api, "~> 1.0"}
   ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -10,3 +10,7 @@
            ]}.
 
 {xref_checks, [undefined_function_calls]}.
+
+{deps, [
+  {opentelemetry_api,  "~> 1.0"}
+  ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,1 +1,8 @@
-[].
+{"1.2.0",
+[{<<"opentelemetry_api">>,{pkg,<<"opentelemetry_api">>,<<"1.0.2">>},0}]}.
+[
+{pkg_hash,[
+ {<<"opentelemetry_api">>, <<"91353EE40583B1D4F07D7B13ED62642ABFEC6AAA0D8A2114F07EDAFB2DF781C5">>}]},
+{pkg_hash_ext,[
+ {<<"opentelemetry_api">>, <<"2A8247F85C44216B883900067478D59955D11E58E5CFCA7C884CD4F203ACE3AC">>}]}
+].

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,8 +1,13 @@
 {"1.2.0",
-[{<<"opentelemetry_api">>,{pkg,<<"opentelemetry_api">>,<<"1.0.2">>},0}]}.
+[{<<"opentelemetry_api">>,{pkg,<<"opentelemetry_api">>,<<"1.3.0">>},0},
+ {<<"opentelemetry_semantic_conventions">>,
+  {pkg,<<"opentelemetry_semantic_conventions">>,<<"0.2.0">>},
+  1}]}.
 [
 {pkg_hash,[
- {<<"opentelemetry_api">>, <<"91353EE40583B1D4F07D7B13ED62642ABFEC6AAA0D8A2114F07EDAFB2DF781C5">>}]},
+ {<<"opentelemetry_api">>, <<"03E2177F28DD8D11AAA88E8522C81C2F6A788170FE52F7A65262340961E663F9">>},
+ {<<"opentelemetry_semantic_conventions">>, <<"B67FE459C2938FCAB341CB0951C44860C62347C005ACE1B50F8402576F241435">>}]},
 {pkg_hash_ext,[
- {<<"opentelemetry_api">>, <<"2A8247F85C44216B883900067478D59955D11E58E5CFCA7C884CD4F203ACE3AC">>}]}
+ {<<"opentelemetry_api">>, <<"B9E5FF775FD064FA098DBA3C398490B77649A352B40B0B730A6B7DC0BDD68858">>},
+ {<<"opentelemetry_semantic_conventions">>, <<"D61FA1F5639EE8668D74B527E6806E0503EFC55A42DB7B5F39939D84C07D6895">>}]}
 ].

--- a/src/gen_lb.erl
+++ b/src/gen_lb.erl
@@ -81,13 +81,19 @@ call(Ref, Args) ->
   call(Ref, Args, []).
 
 call(Ref, Args, Options0) ->
+  SpanName = case Ref of
+                _ when is_atom(Ref) ->
+                    iolist_to_binary([<<"gen_lb call ">>, atom_to_binary(Ref)]);
+                _ ->
+                    <<"gen_lb call">>
+             end,
   StartOpts = #{ attributes => #{},
                  links => [],
                  is_recording => true,
                  start_time => opentelemetry:timestamp(),
                  kind => ?SPAN_KIND_INTERNAL
                },
-  ?with_span(gen_lb, StartOpts,
+  ?with_span(SpanName, StartOpts,
     fun (_SpanCtx) ->
       Ctx = otel_ctx:get_current(),
       Options = [{otel_ctx, Ctx}] ++ Options0,

--- a/src/gen_lb.erl
+++ b/src/gen_lb.erl
@@ -247,13 +247,13 @@ do_call(CbMod, Args, From, Node, ParentCtx) ->
                     fun(_SpanCtx) ->
                       case CbMod:exec(Node, Args) of
                         ok           ->
-                          ?set_status(?OTEL_STATUS_OK, <<"no value">>),
+                          ?set_status(?OTEL_STATUS_OK, <<>>),
                           Daddy ! {Ref, ok};
                         {ok, Res}    ->
-                          ?set_status(?OTEL_STATUS_OK, <<"value">>),
+                          ?set_status(?OTEL_STATUS_OK, <<>>),
                           Daddy ! {Ref, {ok, Res}};
                         {error, Rsn} ->
-                          ?set_status(?OTEL_STATUS_ERROR, <<"call error">>),
+                          ?set_status(?OTEL_STATUS_ERROR, <<>>),
                           Daddy ! {Ref, {error, Rsn}}
                       end
                     end)

--- a/src/yamq.app.src
+++ b/src/yamq.app.src
@@ -4,6 +4,7 @@
  , {registered,   []}
  , {applications, [ kernel
                   , stdlib
+                  , opentelemetry_api
                   ]}
  , {env,          []}
  , {modules,      []}


### PR DESCRIPTION
One span when gen_lb is called and one span before worker exec callback is called (shows time to execute when the workers are very busy).